### PR TITLE
Chainlink-11: Indicate that ride is woman-only or non-binary welcome

### DIFF
--- a/src/components/RideFeedCard.tsx
+++ b/src/components/RideFeedCard.tsx
@@ -47,6 +47,22 @@ const RideFeedCard: React.FC<RideFeedCardProps> = ({ event, setEvent }) => {
     }
   };
 
+  const generateTags = () => {
+    if (event.women_only) 
+    {
+        return (
+            <div className='women-only-tag'>Women Only</div>
+        )
+    } 
+    else if (event.nonbinary_only) 
+    {
+        return (
+            <div className='nonbinary-only-tag'>Nonbinary Only</div>
+        )
+    }
+      
+  }
+
   const { data: routeData } = useQuery(FETCH_ROUTE, {
     variables: {
       routeID: event.route,
@@ -152,6 +168,8 @@ const RideFeedCard: React.FC<RideFeedCardProps> = ({ event, setEvent }) => {
               <span>
                 Share <i className='fa-regular fa-paper-plane'></i>
               </span>
+              <span>{generateTags()}</span>
+              
             </div>
             <RsvpButton
               eventID={event._id}

--- a/src/routes/app/RidesFeed.tsx
+++ b/src/routes/app/RidesFeed.tsx
@@ -548,6 +548,8 @@ export const FETCH_RIDES = gql`
       route
       participants
       match
+      women_only
+      nonbinary_only
     }
   }
 `;

--- a/src/styles/components/ride-feed-card.css
+++ b/src/styles/components/ride-feed-card.css
@@ -187,7 +187,19 @@
 }
 
 
+.women-only-tag, .nonbinary-only-tag {
+    border-radius: 10px;
+    padding: 2px 5px 2px 5px;
+    color: #000;
+}
 
+.women-only-tag {
+    background: #ff99dd;
+}
+
+.nonbinary-only-tag {
+    background: #ffff80;
+}
 
 
 


### PR DESCRIPTION
Added front-end display for event gender filters. This does not include filtering based on these event (that is [Chainlink-5](https://heartratehackers.atlassian.net/browse/CHAINLINK-5?atlOrigin=eyJpIjoiNzIxMDkyZDFkZTQ5NGM3YjhhMjc5ZWYwMGYxYzgzNDYiLCJwIjoiaiJ9)). This also does not include the ability to create a ride with these filters (that is [Chainlink-1](https://heartratehackers.atlassian.net/browse/CHAINLINK-1?atlOrigin=eyJpIjoiMjRiMTFhZmEwZWVlNDkwZGE3MDFjNzMxMmM0OGRmMDciLCJwIjoiaiJ9)). I created one event for each filter, if you want to create more it has to be done in the Mongo database directly.