### PR TITLE
Chainlink 11: Indicate that ride is woman-only or non-binary welcome

### DIFF
--- a/src/components/RideFeedCard.tsx
+++ b/src/components/RideFeedCard.tsx
@@ -47,6 +47,22 @@ const RideFeedCard: React.FC<RideFeedCardProps> = ({ event, setEvent }) => {
     }
   };
 
+  const generateTags = () => {
+    if (event.women_only) 
+    {
+        return (
+            <div className='women-only-tag'>Women Only</div>
+        )
+    } 
+    else if (event.nonbinary_only) 
+    {
+        return (
+            <div className='nonbinary-only-tag'>Nonbinary Only</div>
+        )
+    }
+      
+  }
+
   const { data: routeData } = useQuery(FETCH_ROUTE, {
     variables: {
       routeID: event.route,
@@ -152,6 +168,8 @@ const RideFeedCard: React.FC<RideFeedCardProps> = ({ event, setEvent }) => {
               <span>
                 Share <i className='fa-regular fa-paper-plane'></i>
               </span>
+              <span>{generateTags()}</span>
+              
             </div>
             <RsvpButton
               eventID={event._id}

--- a/src/components/RideFeedCard.tsx
+++ b/src/components/RideFeedCard.tsx
@@ -47,22 +47,6 @@ const RideFeedCard: React.FC<RideFeedCardProps> = ({ event, setEvent }) => {
     }
   };
 
-  const generateTags = () => {
-    if (event.women_only) 
-    {
-        return (
-            <div className='women-only-tag'>Women Only</div>
-        )
-    } 
-    else if (event.nonbinary_only) 
-    {
-        return (
-            <div className='nonbinary-only-tag'>Nonbinary Only</div>
-        )
-    }
-      
-  }
-
   const { data: routeData } = useQuery(FETCH_ROUTE, {
     variables: {
       routeID: event.route,
@@ -144,6 +128,16 @@ const RideFeedCard: React.FC<RideFeedCardProps> = ({ event, setEvent }) => {
       </div>
       {routeData ? (
         <div className='ride-feed-card-values'>
+            
+            <div className='ride-feed-card-tags'>
+              {event.privateWomen ? (
+                <div className='tag'>Private: Women</div>
+              ) : (<div></div>) }
+              {event.privateNonBinary? (
+                <div className='tag'>Private: Non-Binary</div>
+              ) : (<div></div>) }
+            </div>
+
           <h2>{event.name}</h2>
           <p>
             Created by <b>{event.host}</b>
@@ -168,8 +162,6 @@ const RideFeedCard: React.FC<RideFeedCardProps> = ({ event, setEvent }) => {
               <span>
                 Share <i className='fa-regular fa-paper-plane'></i>
               </span>
-              <span>{generateTags()}</span>
-              
             </div>
             <RsvpButton
               eventID={event._id}

--- a/src/routes/app/RidesFeed.tsx
+++ b/src/routes/app/RidesFeed.tsx
@@ -547,9 +547,9 @@ export const FETCH_RIDES = gql`
       intensity
       route
       participants
+      privateWomen
+      privateNonBinary
       match
-      women_only
-      nonbinary_only
     }
   }
 `;

--- a/src/routes/app/RidesFeed.tsx
+++ b/src/routes/app/RidesFeed.tsx
@@ -548,6 +548,8 @@ export const FETCH_RIDES = gql`
       route
       participants
       match
+      women_only
+      nonbinary_only
     }
   }
 `;

--- a/src/styles/components/ride-feed-card.css
+++ b/src/styles/components/ride-feed-card.css
@@ -187,7 +187,19 @@
 }
 
 
+.women-only-tag, .nonbinary-only-tag {
+    border-radius: 10px;
+    padding: 2px 5px 2px 5px;
+    color: #000;
+}
 
+.women-only-tag {
+    background: #ff99dd;
+}
+
+.nonbinary-only-tag {
+    background: #ffff80;
+}
 
 
 

--- a/src/styles/components/ride-feed-card.css
+++ b/src/styles/components/ride-feed-card.css
@@ -7,8 +7,9 @@
     align-items: flex-end;
     gap: 24px;
     position: relative;
+    width: 700px;
 }
-.ride-feed-card-main-container:hover {
+.card-map-view:hover {
     cursor: pointer;
 }
 
@@ -102,8 +103,30 @@
 .ride-feed-card-main-container > .ride-feed-card-matching-score > div i {
     margin-left: 6px;
 }
+/*
+.ride-feed-card-tags {
+    height: 100%;
+    max-width: 150px;
+    /*width: 115px;
+}
+*/
 
+.ride-feed-card-tags {
+    min-width: 100%;
+    display: inline-block;
+}
 
+.tag{
+    text-wrap: nowrap;
+    float: top;
+    float: left;
+    margin: 2px;
+    border-radius: 15px;
+    font-size: 14px;
+    padding: 4px 7px 4px 7px;
+    color: var(--secondary-color);
+    background: var(--primary-color);
+}
 
 
 /* Card Pop over modal */
@@ -187,23 +210,7 @@
 }
 
 
-.women-only-tag, .nonbinary-only-tag {
-    border-radius: 10px;
-    padding: 2px 5px 2px 5px;
-    color: #000;
-}
-
-.women-only-tag {
-    background: #ff99dd;
-}
-
-.nonbinary-only-tag {
-    background: #ffff80;
-}
-
-
-
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: 900px) {
     .ride-feed-card-main-container {
         flex-direction: column;
         align-items: flex-start;
@@ -215,6 +222,10 @@
     }
 
     .ride-feed-card-main-container > .ride-feed-card-values {
+        width: 100%;
+    }
+
+    .ride-feed-card-main-container > .ride-feed-card-tags {
         width: 100%;
     }
 


### PR DESCRIPTION
Made the ride tags for the privacy fields 'privateWomen' and 'privateNonBinary'. Also slightly adjusted the size of the ride view cards to be able to fit both tags side by side. There is minor scaling issues if the right side of the card gets larger then the map but that is beyond the scope of this commit, hopefully that shouldn't happen with the wider cards.

[https://heartratehackers.atlassian.net/browse/CHAINLINK-11?atlOrigin=eyJpIjoiMjYwZjFhZTJlNjYzNDUwZDliNDExMWE4NTdiMjQ0NDMiLCJwIjoiaiJ9](https://heartratehackers.atlassian.net/browse/CHAINLINK-11?atlOrigin=eyJpIjoiMjYwZjFhZTJlNjYzNDUwZDliNDExMWE4NTdiMjQ0NDMiLCJwIjoiaiJ9)